### PR TITLE
feat: issue dummy credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,16 @@ SESSION_SECRET=
 UNUM_API_KEY=
 CORE_SERVICE_URL='https://core-api.sandbox-unumid.co'
 
+# Observability, logging, etc - not needed to run locally
+# LogRocket
+LOG_ROCKET_ID=
+LOG_ROCKET_PROJECT_NAME=
+
 # winston
 LOG_LEVEL=debug
 
-# New Relic
+# New Relic - not needed to run locally
 NEW_RELIC_ENABLED=false
+NEW_RELIC_APP_NAME=
+NEW_RELIC_LICENSE_KEY=
+NEW_RELIC_LOGGING_LICENSE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,12 @@
 # Environment
 NODE_ENV=local
-PORT=3000
+PORT=7040
 SESSION_SECRET=
 UNUM_API_KEY=
-CORE_SERVICE_URL=
-
-# Observability, logging, etc
-# LogRocket
-LOG_ROCKET_ID=
-LOG_ROCKET_PROJECT_NAME=
+CORE_SERVICE_URL='https://core-api.sandbox-unumid.co'
 
 # winston
 LOG_LEVEL=debug
 
 # New Relic
-NEW_RELIC_ENABLED=
-NEW_RELIC_APP_NAME=
-NEW_RELIC_LICENSE_KEY=
-NEW_RELIC_LOGGING_LICENSE_KEY=
+NEW_RELIC_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The live web app can be found [here](https://hooli-web.demo.sandbox-unumid.co).
 
 The application's home page is a sample login page. In order to sign in, you may enter any combination of email address and password. _Please note, if the email address is not valid email format, credentials will not successfully issue on subsequent screens._
 
-Once passed the login screen the user is prompted to activate their Unum ID digital identity card or not. If agreed to, an EmailCredential is issued corresponding to the authenticated user.
+Once passed the login screen the user is prompted to activate their Unum ID digital identity card or not. If agreed to, an EmailCredential is issued corresponding to the authenticated user. A number of 'dummy' credentials (e.g. FullNameCredential, SsnCredential) will also be issued for the user.
 
 The critical api call to [/credentials](https://docs.unumid.co/api-overview#issue-credentials) for issuing the credentials can be found in the [coreAPI.server.ts](/app/coreAPI.server.ts) file. By issuing credentials Hooli qualifies themselves for Unum ID's [Free IDV](https://docs.unumid.co/api-overview#free-idv-guide) offering.
 
@@ -32,6 +32,12 @@ Install necessary dependencies
 npm install
 ```
 
+Make a clone of the `.env.example` file and save as `.env` in the demo's root directory. There are a few items worth noting for setting up the `.env`.
+
+- `PORT` can be updated to whichever port you'd prefer the demo to run on locally.
+- `UNUM_API_KEY` needs to be populated with the API key you've been provided.
+- `CORE_SERVICE_URL` is defaulted to the Unum ID Core Service API in our sandbox environment.
+
 ### Running
 
 Start the Remix development asset server and the Express server by running:
@@ -40,4 +46,4 @@ Start the Remix development asset server and the Express server by running:
 npm run dev
 ```
 
-The demo will launch on port 7040.
+_Note: The demo will launch on the specified `PORT` in the `.env` file._

--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -43,9 +43,58 @@ export const issueCredentials = async (
     data: { email },
   };
 
+  // For the purposes of the demo, these credentials are hard coded with dummy data.
+  // The intent is to highlight the variety of credential data available for issuance.
+  const dummyCredentials: Credential[] = [
+    {
+      type: 'FullNameCredential',
+      data: { fullName: 'Richard Hendricks' },
+    },
+    {
+      type: 'PhoneCredential',
+      data: { phone: '+10123456789' },
+    },
+    {
+      type: 'SexCredential',
+      data: { sex: 'male' },
+    },
+    {
+      type: 'DobCredential',
+      data: { dob: '575856000' },
+    },
+    {
+      type: 'SsnCredential',
+      data: { ssn: 111223333 },
+    },
+    {
+      type: 'NationalityCredential',
+      data: { nationality: 'United States' },
+    },
+    {
+      type: 'GovernmentIdTypeCredential',
+      data: { documentType: "Driver's License" },
+    },
+    {
+      type: 'GovernmentIdStateCredential',
+      data: { state: 'California' },
+    },
+    {
+      type: 'GovernmentIdNumberCredential',
+      data: { idNumber: 6383736743891101 },
+    },
+    {
+      type: 'GovernmentIdIssuanceDateCredential',
+      data: { issuanceDate: '21945600000' },
+    },
+    {
+      type: 'GovernmentIdExpirationDateCredential',
+      data: { expirationDate: '1883951999000' },
+    },
+  ];
+
   const options: CredentialOptions = {
     email,
-    credentials: [credential],
+    credentials: [credential, ...dummyCredentials],
   };
 
   const body = JSON.stringify(options);


### PR DESCRIPTION
[Hooli Demo Issue Dummy Credentials](https://trello.com/c/OzGCgNWJ/4941-update-hooli-demo-to-always-issue-a-set-of-dummy-credentials-always-issue-a-set-of-dummy-credentials)

## Summary
Update demo to always issue a set of dummy credentials.

## Changes
- Updated coreAPI to always issue a set of dummy credentials along with the EmailCredential issued based on the user inputted value.
- Updated README
- Removed unnecessary variables from the .env.example file 

## Testing
Confirmed credentials were issued locally.

## Checklist

- [x] I have performed a self-review of my code
- ~[ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_~
- [x] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- ~[ ] If it is a core feature, I have added an appropriate amount of unit tests.~
- ~[ ] Any dependent changes have been merged and published in upstream projects~