### PR TITLE
feat: use phone provided in registration, don't issue dummy phone

### DIFF
--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -27,10 +27,12 @@ interface CredentialOptions {
  *
  * Documentation: https://docs.unumid.co/api-overview#issue-credentials
  * @param {string} email
+ * @param {string} phone
  * @returns {Promise<'success' | 'error'>}
  */
 export const issueCredentials = async (
-  email: string | null
+  email: string | null,
+  phone?: string | null
 ): Promise<'success' | 'error'> => {
   if (!email) return 'error'; // short circuit if no user email provided
   const headers = {
@@ -51,10 +53,6 @@ export const issueCredentials = async (
       data: { fullName: 'Richard Hendricks' },
     },
     {
-      type: 'PhoneCredential',
-      data: { phone: '+10123456789' },
-    },
-    {
       type: 'SexCredential',
       data: { sex: 'Male' },
     },
@@ -64,7 +62,7 @@ export const issueCredentials = async (
     },
     {
       type: 'SsnCredential',
-      data: { ssn: 111223333 },
+      data: { ssn: '000000000' },
     },
     {
       type: 'NationalityCredential',
@@ -92,10 +90,19 @@ export const issueCredentials = async (
     },
   ];
 
+  if (phone) {
+    dummyCredentials.push({
+      type: 'PhoneCredential',
+      data: { phone },
+    });
+  }
+
   const options: CredentialOptions = {
     email,
     credentials: [credential, ...dummyCredentials],
   };
+
+  if (phone) options.phone = phone;
 
   const body = JSON.stringify(options);
 

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import { useState } from 'react';
-import { getUserEmail, logout, requireUserEmail } from '../session.server';
+import { getUser, logout, requireUserEmail } from '../session.server';
 import { issueCredentials } from '../coreAPI.server';
 import IDModal from '../components/IDDialog';
 import { Container } from '@mui/system';
@@ -31,8 +31,8 @@ export const action: ActionFunction = async ({ request }) => {
       return await logout(request);
     }
     case 'activate1Click': {
-      const email = await getUserEmail(request);
-      return await issueCredentials(email);
+      const { email, phone } = await getUser(request);
+      return await issueCredentials(email, phone);
     }
     default: {
       return null;

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -26,6 +26,10 @@ export const action: ActionFunction = async ({ request }) => {
     return json({ error: 'Email is required' }, { status: 400 });
   }
 
+  if (!phone) {
+    return json({ error: 'Phone is required' }, { status: 400 });
+  }
+
   if (!password) {
     return json({ error: 'Password is required' }, { status: 400 });
   }
@@ -33,13 +37,13 @@ export const action: ActionFunction = async ({ request }) => {
   if (
     typeof email !== 'string' ||
     typeof password !== 'string' ||
-    (phone && typeof phone !== 'string')
+    typeof phone !== 'string'
   ) {
     return json({ error: 'Invalid form data' }, { status: 400 });
   }
 
   try {
-    return createUserSession(request, email);
+    return createUserSession(request, email, phone);
   } catch (e) {
     return json({ error: getErrorMessage(e) }, { status: getErrorStatus(e) });
   }

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -83,7 +83,7 @@ export const requireUserEmail = async (request: Request): Promise<string> => {
 export const createUserSession = async (
   request: Request,
   email: string,
-  phone?: string,
+  phone = '',
   redirectTo = '/?prompt=true'
 ) => {
   const session = await getSession(request);

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -21,8 +21,8 @@ export const sessionStorage = createCookieSessionStorage({
   },
 });
 
-// key for getting/setting the user email in the session
-const USER_SESSION_KEY = 'userEmail';
+// key for getting/setting the user in the session
+const USER_SESSION_KEY = 'user';
 
 /**
  * Gets the session from the request
@@ -37,13 +37,13 @@ export const getSession = async (request: Request) => {
 /**
  * Gets the user from the session
  * @param {Request} request
- * @returns {Promise<string | null>} user
+ * @returns {Promise<Record<string, string | null>>} user
  */
-export const getUserEmail = async (request: Request) => {
+export const getUser = async (request: Request) => {
   const session = await getSession(request);
-  const email = session.get(USER_SESSION_KEY);
+  const user = session.get(USER_SESSION_KEY);
 
-  return email;
+  return { ...user };
 };
 
 /**
@@ -68,9 +68,9 @@ export const logout = async (request: Request) => {
  * @returns {Promise<string>} email
  */
 export const requireUserEmail = async (request: Request): Promise<string> => {
-  const email = await getUserEmail(request);
+  const user = await getUser(request);
 
-  if (email) return email;
+  if (user?.email) return user.email;
 
   throw await logout(request);
 };
@@ -83,10 +83,15 @@ export const requireUserEmail = async (request: Request): Promise<string> => {
 export const createUserSession = async (
   request: Request,
   email: string,
+  phone?: string,
   redirectTo = '/?prompt=true'
 ) => {
   const session = await getSession(request);
-  session.set(USER_SESSION_KEY, email);
+  const sessionValue = {
+    email,
+    phone,
+  };
+  session.set(USER_SESSION_KEY, sessionValue);
   return redirect(redirectTo, {
     headers: {
       'Set-Cookie': await sessionStorage.commitSession(session),


### PR DESCRIPTION
[Ticket](https://trello.com/c/Ztc1CakX/5064-use-registration-phone-for-credential-issuance-and-user-creation-hooli-demo)

## Summary
Update Hooli demo to use registration phone input in credential issuance and user creation.

## Changes
- Updated user session to persist phone from registration page when provided.
- Stopped issuance of dummy phone credential. Phone credential only issued when a user's phone is provided on registration.
- Updated dummy SsnCredential

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- ~[ ] I have made any relevant corresponding changes to the documentation including the project readme.~
- [x] I have run and tested the changes locally
- ~[ ] If it is a core feature, I have added an appropriate amount of unit tests.~
- ~[ ] Any dependent changes have been merged and published in upstream projects~